### PR TITLE
Improve AI suggester streaming output

### DIFF
--- a/backend/routes/ai.js
+++ b/backend/routes/ai.js
@@ -1,7 +1,7 @@
 // backend/routes/ai.js
 import express from 'express';
 import pool from '../db.js';
-import { GoogleGenAI, Type } from '@google/genai';
+import { GoogleGenAI } from '@google/genai';
 import { agentApp } from '../services/langchain/agent.js';
 import { HumanMessage } from "@langchain/core/messages";
 import crypto from 'crypto';
@@ -65,75 +65,96 @@ router.post('/ai/chat', async (req, res) => {
 });
 
 
+const tryParseJson = (value) => {
+    if (!value || typeof value !== 'string') return null;
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const jsonRegex = /```(?:json)?\s*([\s\S]*?)\s*```/i;
+    const match = trimmed.match(jsonRegex);
+    const candidate = match && match[1] ? match[1] : trimmed;
+    try {
+        return JSON.parse(candidate);
+    } catch (e) {
+        return null;
+    }
+};
+
+const extractTextFromContent = (content) => {
+    if (!content) return '';
+    if (typeof content === 'string') return content;
+    if (Array.isArray(content)) {
+        return content
+            .map(part => {
+                if (!part) return '';
+                if (typeof part === 'string') return part;
+                if (typeof part.text === 'string') return part.text;
+                return '';
+            })
+            .filter(Boolean)
+            .join('\n');
+    }
+    if (typeof content === 'object' && typeof content.text === 'string') {
+        return content.text;
+    }
+    return '';
+};
+
+const formatToolObservation = (content) => {
+    const text = extractTextFromContent(content) || (typeof content === 'string' ? content : '');
+    const parsed = tryParseJson(text);
+    if (parsed && typeof parsed === 'object') {
+        return JSON.stringify(parsed, null, 2);
+    }
+    return text || (typeof content === 'object' ? JSON.stringify(content) : '');
+};
+
+const sendSse = (res, payload) => {
+    res.write(`data: ${JSON.stringify(payload)}\n\n`);
+    if (typeof res.flush === 'function') {
+        try { res.flush(); } catch (_) { /* ignore */ }
+    }
+};
+
 const streamAndRecordConversation = async (res, conversationId, messages, isNewConversation = true) => {
     let finalMessages = [...messages];
-    
+
     if (isNewConversation) {
-        res.write(`data: ${JSON.stringify({ type: 'conversationStart', content: { conversationId } })}\n\n`);
+        sendSse(res, { type: 'conversationStart', content: { conversationId } });
     }
 
     const stream = await agentApp.stream({ messages });
 
     for await (const chunk of stream) {
         if (chunk.agent) {
-            (chunk.agent.messages || []).forEach(async msg => {
-                finalMessages.push(msg); // Add agent's own messages to history
-                
-                // --- EMIT THOUGHT & ACTION ---
+            (chunk.agent.messages || []).forEach(msg => {
+                finalMessages.push(msg);
+
+                const messageText = extractTextFromContent(msg.content).trim();
+
                 if (msg.tool_calls?.length) {
-                    if (typeof msg.content === 'string' && msg.content.trim()) {
-                         res.write(`data: ${JSON.stringify({ type: 'thought', content: msg.content.trim() })}\n\n`);
+                    if (messageText) {
+                        sendSse(res, { type: 'thought', content: messageText });
                     }
 
                     msg.tool_calls.forEach(toolCall => {
                         let argsString;
                         try {
-                            // Pretty-print the JSON arguments for better readability in the trace
                             argsString = JSON.stringify(toolCall.args, null, 2);
                         } catch (e) {
-                            // Fallback for non-JSON or malformed args
                             argsString = JSON.stringify(toolCall.args);
                         }
-                        const action = `${toolCall.name}${argsString}`;
-                        res.write(`data: ${JSON.stringify({ type: 'action', content: action })}\n\n`);
+                        sendSse(res, { type: 'action', content: `${toolCall.name}${argsString || ''}` });
                     });
+                } else {
+                    const maybeJson = tryParseJson(messageText);
 
-                } else if (msg.content && typeof msg.content === 'string') {
-                     try {
-                        // FIX: Use a robust regex to extract JSON from a string, even if it's wrapped in markdown.
-                        const jsonRegex = /```(?:json)?\s*([\s\S]*?)\s*```/;
-                        const match = msg.content.match(jsonRegex);
-                        let finalJson;
-
-                        if (match && match[1]) {
-                            // If a JSON block is found in markdown, parse its content.
-                            finalJson = JSON.parse(match[1]);
-                        } else {
-                            // Otherwise, assume the entire content is the JSON string.
-                            finalJson = JSON.parse(msg.content);
+                    if (maybeJson && typeof maybeJson === 'object' && (maybeJson.rule || maybeJson.reasoning)) {
+                        if (typeof maybeJson.reasoning === 'string' && maybeJson.reasoning.trim()) {
+                            sendSse(res, { type: 'agent', content: maybeJson.reasoning.trim() });
                         }
-                        
-                        // --- Generate Natural Language Summary ---
-                        try {
-                            const summaryPrompt = `Dựa trên đối tượng JSON sau đây chứa một đề xuất rule PPC và lý do, hãy viết một bản tóm tắt bằng ngôn ngữ tự nhiên, thân thiện cho người dùng. Giải thích ngắn gọn rule đó làm gì và tại sao nó được đề xuất. JSON:\n\n${JSON.stringify(finalJson, null, 2)}`;
-                            const summaryResponse = await ai.models.generateContent({
-                                model: 'gemini-2.5-flash',
-                                contents: summaryPrompt,
-                            });
-                            // Stream the natural language summary first
-                            res.write(`data: ${JSON.stringify({ type: 'agent', content: summaryResponse.text })}\n\n`);
-                        } catch(summaryError) {
-                             console.error("Failed to generate summary:", summaryError);
-                             // If summary fails, still send the main result
-                        }
-                        // --- END ---
-
-                        // Always stream the structured JSON result
-                        res.write(`data: ${JSON.stringify({ type: 'result', content: finalJson })}\n\n`);
-
-                    } catch (e) {
-                         // This is a text response to a follow-up question.
-                         res.write(`data: ${JSON.stringify({ type: 'agent', content: msg.content })}\n\n`);
+                        sendSse(res, { type: 'result', content: maybeJson });
+                    } else if (messageText) {
+                        sendSse(res, { type: 'agent', content: messageText });
                     }
                 }
             });
@@ -144,11 +165,14 @@ const streamAndRecordConversation = async (res, conversationId, messages, isNewC
 
             messagesArray.forEach(msg => {
                 finalMessages.push(msg);
-                res.write(`data: ${JSON.stringify({ type: 'observation', content: msg.content })}\n\n`);
+                const formatted = formatToolObservation(msg.content);
+                if (formatted) {
+                    sendSse(res, { type: 'observation', content: formatted });
+                }
             });
         }
     }
-    
+
     conversations.set(conversationId, finalMessages);
     res.end();
 };


### PR DESCRIPTION
## Summary
- normalize streamed agent messages into human-friendly SSE events
- add helpers that format tool thoughts, actions, and observations for the UI trace
- ensure structured results emit both reasoning text and parsed JSON for the AI suggester tab

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d760984180833199bdef8175200e1c