### PR TITLE
Improve AI suggester stream narration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/


### PR DESCRIPTION
## Summary
- convert AI suggester streaming payloads into Vietnamese narration for agent thoughts, tool calls, and observations
- format structured tool responses into readable metrics before sending SSE updates
- ignore build artifacts and dependencies to keep the repo clean

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d760984180833199bdef8175200e1c